### PR TITLE
fix: `legacyBehavior` is deprecated

### DIFF
--- a/components/ui/navigation.tsx
+++ b/components/ui/navigation.tsx
@@ -127,11 +127,11 @@ export default function Navigation({
         {menuItems.map((item, index) => (
           <NavigationMenuItem key={index}>
             {item.isLink ? (
-              <Link href={item.href || ""} legacyBehavior passHref>
-                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+              <NavigationMenuLink className={navigationMenuTriggerStyle()} asChild>
+                <Link href={item.href || ""}>
                   {item.title}
-                </NavigationMenuLink>
-              </Link>
+                </Link>
+              </NavigationMenuLink>
             ) : (
               <>
                 <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>


### PR DESCRIPTION
This fixes deprecated error on new Next.js versions.